### PR TITLE
Implement NBI mappings for interfaces/links/service requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	google.golang.org/genproto v0.0.0-20251124214823-79d6a2a48846 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
+	google.golang.org/protobuf v1.36.10
 )
 
 replace aalyria.com/spacetime v0.0.0 => ./internal/genproto/aalyria

--- a/internal/nbi/types/types.go
+++ b/internal/nbi/types/types.go
@@ -2,12 +2,15 @@ package types
 
 import (
 	"errors"
+	"strings"
+	"time"
 
 	core "github.com/signalsfoundry/constellation-simulator/core"
 	"github.com/signalsfoundry/constellation-simulator/model"
 
 	common "aalyria.com/spacetime/api/common"
 	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 //
@@ -193,41 +196,341 @@ func NodeToProto(dom *model.NetworkNode) *NetworkNode {
 // InterfaceFromProto converts an Aalyria NetworkInterface into the
 // simulator's core.NetworkInterface representation.
 func InterfaceFromProto(iface *NetworkInterface) (*core.NetworkInterface, error) {
-	// TODO: implement in later Scope 3 chunk.
-	panic("InterfaceFromProto not implemented yet")
+	if iface == nil {
+		return nil, errors.New("nil NetworkInterface proto")
+	}
+
+	medium := core.MediumType("")
+	transceiverID := ""
+
+	switch m := iface.GetInterfaceMedium().(type) {
+	case *resources.NetworkInterface_Wired:
+		medium = core.MediumWired
+	case *resources.NetworkInterface_Wireless:
+		medium = core.MediumWireless
+		if m.Wireless != nil && m.Wireless.TransceiverModelId != nil {
+			transceiverID = m.Wireless.TransceiverModelId.GetTransceiverModelId()
+		}
+	}
+
+	isOperational := len(iface.GetOperationalImpairment()) == 0
+
+	return &core.NetworkInterface{
+		ID:            iface.GetInterfaceId(),
+		Name:          iface.GetName(),
+		Medium:        medium,
+		TransceiverID: transceiverID,
+		ParentNodeID:  "",
+		IsOperational: isOperational,
+		MACAddress:    iface.GetEthernetAddress(),
+		IPAddress:     iface.GetIpAddress(),
+	}, nil
 }
 
 // InterfaceToProto converts a core.NetworkInterface back into the
 // Aalyria NetworkInterface proto.
 func InterfaceToProto(iface *core.NetworkInterface) *NetworkInterface {
-	// TODO: implement in later Scope 3 chunk.
-	panic("InterfaceToProto not implemented yet")
+	if iface == nil {
+		return nil
+	}
+
+	id := iface.ID
+	name := iface.Name
+	ip := iface.IPAddress
+	mac := iface.MACAddress
+
+	p := &resources.NetworkInterface{
+		InterfaceId: &id,
+	}
+
+	if name != "" {
+		p.Name = &name
+	}
+	if ip != "" {
+		p.IpAddress = &ip
+	}
+	if mac != "" {
+		p.EthernetAddress = &mac
+	}
+
+	switch iface.Medium {
+	case core.MediumWired:
+		p.InterfaceMedium = &resources.NetworkInterface_Wired{
+			Wired: &resources.WiredDevice{},
+		}
+	default:
+		wd := &resources.WirelessDevice{}
+		if iface.TransceiverID != "" {
+			trx := iface.TransceiverID
+			wd.TransceiverModelId = &common.TransceiverModelId{
+				TransceiverModelId: &trx,
+			}
+		}
+		p.InterfaceMedium = &resources.NetworkInterface_Wireless{
+			Wireless: wd,
+		}
+	}
+
+	if !iface.IsOperational {
+		imp := resources.NetworkInterface_Impairment_DEFAULT_UNUSABLE
+		p.OperationalImpairment = []*resources.NetworkInterface_Impairment{
+			{Type: &imp},
+		}
+	}
+
+	return p
 }
 
 // LinkFromProto converts an Aalyria NetworkLink into the simulator's
 // core.NetworkLink representation.
 func LinkFromProto(link *NetworkLink) (*core.NetworkLink, error) {
-	// TODO: implement in later Scope 3 chunk.
-	panic("LinkFromProto not implemented yet")
+	if link == nil {
+		return nil, errors.New("nil NetworkLink proto")
+	}
+
+	srcNode := link.GetSrcNetworkNodeId()
+	dstNode := link.GetDstNetworkNodeId()
+	srcIface := link.GetSrcInterfaceId()
+	dstIface := link.GetDstInterfaceId()
+
+	// Support deprecated src/dst fields as a fallback.
+	if srcIface == "" && link.GetSrc() != nil {
+		srcNode = link.GetSrc().GetNodeId()
+		srcIface = link.GetSrc().GetInterfaceId()
+	}
+	if dstIface == "" && link.GetDst() != nil {
+		dstNode = link.GetDst().GetNodeId()
+		dstIface = link.GetDst().GetInterfaceId()
+	}
+
+	intA := combineInterfaceRef(srcNode, srcIface)
+	intB := combineInterfaceRef(dstNode, dstIface)
+
+	return &core.NetworkLink{
+		ID:         combineLinkID(intA, intB),
+		InterfaceA: intA,
+		InterfaceB: intB,
+		Medium:     core.MediumWireless,
+		IsUp:       true,
+		IsStatic:   true,
+	}, nil
 }
 
 // LinkToProto converts a core.NetworkLink back into the Aalyria
 // NetworkLink proto.
 func LinkToProto(link *core.NetworkLink) *NetworkLink {
-	// TODO: implement in later Scope 3 chunk.
-	panic("LinkToProto not implemented yet")
+	if link == nil {
+		return nil
+	}
+
+	srcNode, srcIface := splitInterfaceRef(link.InterfaceA)
+	dstNode, dstIface := splitInterfaceRef(link.InterfaceB)
+
+	p := &resources.NetworkLink{}
+
+	if srcNode != "" || srcIface != "" {
+		p.SrcNetworkNodeId = stringPtr(srcNode)
+		p.SrcInterfaceId = stringPtr(srcIface)
+	}
+	if dstNode != "" || dstIface != "" {
+		p.DstNetworkNodeId = stringPtr(dstNode)
+		p.DstInterfaceId = stringPtr(dstIface)
+	}
+
+	// Populate deprecated fields for compatibility if we have both halves.
+	if srcNode != "" && srcIface != "" {
+		p.Src = &common.NetworkInterfaceId{
+			NodeId:      &srcNode,
+			InterfaceId: &srcIface,
+		}
+	}
+	if dstNode != "" && dstIface != "" {
+		p.Dst = &common.NetworkInterfaceId{
+			NodeId:      &dstNode,
+			InterfaceId: &dstIface,
+		}
+	}
+
+	return p
 }
 
 // ServiceRequestFromProto converts an Aalyria ServiceRequest into the
 // simulator's domain ServiceRequest representation.
+//
+// Note: The proto does not carry a stable request_id. We treat the proto
+// `type` field as a human-readable label and map it onto ServiceRequest.Type.
+// The stable ID is owned by the NBI / ScenarioState layer and is not set here.
 func ServiceRequestFromProto(sr *ServiceRequest) (*model.ServiceRequest, error) {
-	// TODO: implement in later Scope 3 chunk.
-	panic("ServiceRequestFromProto not implemented yet")
+    if sr == nil {
+        return nil, errors.New("nil ServiceRequest proto")
+    }
+
+    dom := &model.ServiceRequest{
+        ID:                    "",              // ID is intentionally NOT derived from proto.type
+        Type:                  sr.GetType(),    // type label from proto
+        SrcNodeID:             sr.GetSrcNodeId(),
+        DstNodeID:             sr.GetDstNodeId(),
+        Priority:              int32(sr.GetPriority()),
+        AllowPartnerResources: sr.GetAllowPartnerResources(),
+    }
+
+    for _, req := range sr.GetRequirements() {
+        if req == nil {
+            continue
+        }
+
+        fr := model.FlowRequirement{
+            RequestedBandwidthMbps: req.GetBandwidthBpsRequested() / 1e6,
+            MinBandwidthMbps:       req.GetBandwidthBpsMinimum() / 1e6,
+            MaxLatencyMs:           durationToMilliseconds(req.GetLatencyMaximum()),
+        }
+
+        if ti := req.GetTimeInterval(); ti != nil {
+            fr.ValidFromUnixSec = dateTimeToUnixSeconds(ti.GetStartTime())
+            fr.ValidToUnixSec = dateTimeToUnixSeconds(ti.GetEndTime())
+        }
+
+        if req.GetIsDisruptionTolerant() {
+            dom.IsDisruptionTolerant = true
+        }
+
+        dom.FlowRequirements = append(dom.FlowRequirements, fr)
+    }
+
+    return dom, nil
 }
 
 // ServiceRequestToProto converts a domain ServiceRequest back into the
 // Aalyria ServiceRequest proto.
+//
+// We emit the human-readable Type label into proto.type.
+// The internal ID is not exposed on the wire here; it is used by NBI
+// request messages (request_id) and ScenarioState storage.
 func ServiceRequestToProto(sr *model.ServiceRequest) *ServiceRequest {
-	// TODO: implement in later Scope 3 chunk.
-	panic("ServiceRequestToProto not implemented yet")
+    if sr == nil {
+        return nil
+    }
+
+    p := &resources.ServiceRequest{}
+
+    if sr.Type != "" {
+        typ := sr.Type
+        p.Type = &typ
+    }
+
+    if sr.SrcNodeID != "" {
+        src := sr.SrcNodeID
+        p.SrcType = &resources.ServiceRequest_SrcNodeId{SrcNodeId: src}
+    }
+    if sr.DstNodeID != "" {
+        dst := sr.DstNodeID
+        p.DstType = &resources.ServiceRequest_DstNodeId{DstNodeId: dst}
+    }
+
+    if sr.Priority != 0 {
+        pr := float64(sr.Priority)
+        p.Priority = &pr
+    }
+
+    for _, fr := range sr.FlowRequirements {
+        req := &resources.ServiceRequest_FlowRequirements{}
+
+        if fr.RequestedBandwidthMbps != 0 {
+            bps := fr.RequestedBandwidthMbps * 1e6
+            req.BandwidthBpsRequested = &bps
+        }
+        if fr.MinBandwidthMbps != 0 {
+            min := fr.MinBandwidthMbps * 1e6
+            req.BandwidthBpsMinimum = &min
+        }
+        if fr.MaxLatencyMs != 0 {
+            req.LatencyMaximum = millisecondsToDuration(fr.MaxLatencyMs)
+        }
+        if fr.ValidFromUnixSec != 0 || fr.ValidToUnixSec != 0 {
+            req.TimeInterval = &common.TimeInterval{
+                StartTime: unixSecondsToDateTime(fr.ValidFromUnixSec),
+                EndTime:   unixSecondsToDateTime(fr.ValidToUnixSec),
+            }
+        }
+        if sr.IsDisruptionTolerant {
+            dtn := sr.IsDisruptionTolerant
+            req.IsDisruptionTolerant = &dtn
+        }
+
+        p.Requirements = append(p.Requirements, req)
+    }
+
+    if sr.AllowPartnerResources {
+        apr := sr.AllowPartnerResources
+        p.AllowPartnerResources = &apr
+    }
+
+    return p
+}
+
+
+func combineInterfaceRef(nodeID, ifaceID string) string {
+	switch {
+	case nodeID == "" && ifaceID == "":
+		return ""
+	case nodeID == "":
+		return ifaceID
+	case ifaceID == "":
+		return nodeID
+	default:
+		return nodeID + "/" + ifaceID
+	}
+}
+
+func splitInterfaceRef(ref string) (string, string) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", ref
+}
+
+func combineLinkID(a, b string) string {
+	if a == "" && b == "" {
+		return ""
+	}
+	return a + "<->" + b
+}
+
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func durationToMilliseconds(d *durationpb.Duration) float64 {
+	if d == nil {
+		return 0
+	}
+	return float64(d.AsDuration()) / float64(time.Millisecond)
+}
+
+func millisecondsToDuration(ms float64) *durationpb.Duration {
+	if ms == 0 {
+		return nil
+	}
+	return durationpb.New(time.Duration(ms * float64(time.Millisecond)))
+}
+
+func dateTimeToUnixSeconds(dt *common.DateTime) int64 {
+	if dt == nil {
+		return 0
+	}
+	return dt.GetUnixTimeUsec() / 1_000_000
+}
+
+func unixSecondsToDateTime(sec int64) *common.DateTime {
+	if sec == 0 {
+		return nil
+	}
+	usec := sec * 1_000_000
+	return &common.DateTime{
+		UnixTimeUsec: &usec,
+	}
 }

--- a/internal/nbi/types/types_interface_link_service_request_test.go
+++ b/internal/nbi/types/types_interface_link_service_request_test.go
@@ -1,0 +1,173 @@
+package types
+
+import (
+	"math"
+	"testing"
+
+	core "github.com/signalsfoundry/constellation-simulator/core"
+	"github.com/signalsfoundry/constellation-simulator/model"
+
+	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+)
+
+func TestInterfaceMappingRoundTrip(t *testing.T) {
+	orig := &core.NetworkInterface{
+		ID:            "if-1",
+		Name:          "Wireless0",
+		Medium:        core.MediumWireless,
+		TransceiverID: "trx-123",
+		IsOperational: false,
+		MACAddress:    "01:23:45:67:89:ab",
+		IPAddress:     "10.0.0.1/24",
+	}
+
+	p := InterfaceToProto(orig)
+	if p == nil {
+		t.Fatalf("InterfaceToProto returned nil")
+	}
+
+	back, err := InterfaceFromProto(p)
+	if err != nil {
+		t.Fatalf("InterfaceFromProto returned error: %v", err)
+	}
+
+	if back.ID != orig.ID {
+		t.Errorf("ID mismatch: got %q, want %q", back.ID, orig.ID)
+	}
+	if back.Medium != orig.Medium {
+		t.Errorf("Medium mismatch: got %q, want %q", back.Medium, orig.Medium)
+	}
+	if back.TransceiverID != orig.TransceiverID {
+		t.Errorf("TransceiverID mismatch: got %q, want %q", back.TransceiverID, orig.TransceiverID)
+	}
+	if back.IPAddress != orig.IPAddress {
+		t.Errorf("IPAddress mismatch: got %q, want %q", back.IPAddress, orig.IPAddress)
+	}
+	if back.MACAddress != orig.MACAddress {
+		t.Errorf("MACAddress mismatch: got %q, want %q", back.MACAddress, orig.MACAddress)
+	}
+	if back.IsOperational != orig.IsOperational {
+		t.Errorf("IsOperational mismatch: got %v, want %v", back.IsOperational, orig.IsOperational)
+	}
+}
+
+func TestLinkMappingRoundTrip(t *testing.T) {
+	srcNode := "node-a"
+	dstNode := "node-b"
+	srcIface := "if-a"
+	dstIface := "if-b"
+
+	p := &resources.NetworkLink{
+		SrcNetworkNodeId: &srcNode,
+		DstNetworkNodeId: &dstNode,
+		SrcInterfaceId:   &srcIface,
+		DstInterfaceId:   &dstIface,
+	}
+
+	dom, err := LinkFromProto(p)
+	if err != nil {
+		t.Fatalf("LinkFromProto returned error: %v", err)
+	}
+
+	if dom.InterfaceA != "node-a/if-a" {
+		t.Errorf("InterfaceA mismatch: got %q", dom.InterfaceA)
+	}
+	if dom.InterfaceB != "node-b/if-b" {
+		t.Errorf("InterfaceB mismatch: got %q", dom.InterfaceB)
+	}
+	if dom.ID != "node-a/if-a<->node-b/if-b" {
+		t.Errorf("ID mismatch: got %q", dom.ID)
+	}
+
+	p2 := LinkToProto(dom)
+	if got := p2.GetSrcNetworkNodeId(); got != srcNode {
+		t.Errorf("SrcNetworkNodeId mismatch: got %q, want %q", got, srcNode)
+	}
+	if got := p2.GetDstNetworkNodeId(); got != dstNode {
+		t.Errorf("DstNetworkNodeId mismatch: got %q, want %q", got, dstNode)
+	}
+	if got := p2.GetSrcInterfaceId(); got != srcIface {
+		t.Errorf("SrcInterfaceId mismatch: got %q, want %q", got, srcIface)
+	}
+	if got := p2.GetDstInterfaceId(); got != dstIface {
+		t.Errorf("DstInterfaceId mismatch: got %q, want %q", got, dstIface)
+	}
+}
+
+func TestServiceRequestMappingRoundTrip(t *testing.T) {
+    orig := &model.ServiceRequest{
+        // ID is intentionally NOT part of the proto mapping; it is owned by NBI.
+        // For this roundtrip test we leave it empty.
+        Type:                  "sr-type",
+        SrcNodeID:             "node-1",
+        DstNodeID:             "node-2",
+        Priority:              3,
+        IsDisruptionTolerant:  true,
+        AllowPartnerResources: true,
+        FlowRequirements: []model.FlowRequirement{
+            {
+                RequestedBandwidthMbps: 150,
+                MinBandwidthMbps:       50,
+                MaxLatencyMs:           25,
+                ValidFromUnixSec:       1_000,
+                ValidToUnixSec:         2_000,
+            },
+        },
+    }
+
+    p := ServiceRequestToProto(orig)
+    if p == nil {
+        t.Fatalf("ServiceRequestToProto returned nil")
+    }
+
+    back, err := ServiceRequestFromProto(p)
+    if err != nil {
+        t.Fatalf("ServiceRequestFromProto returned error: %v", err)
+    }
+
+    // Type should roundtrip through the proto.
+    if back.Type != orig.Type {
+        t.Errorf("Type mismatch: got %q, want %q", back.Type, orig.Type)
+    }
+
+    // ID is not derived from the proto; we do NOT assert on back.ID here.
+
+    if back.SrcNodeID != orig.SrcNodeID {
+        t.Errorf("SrcNodeID mismatch: got %q, want %q", back.SrcNodeID, orig.SrcNodeID)
+    }
+    if back.DstNodeID != orig.DstNodeID {
+        t.Errorf("DstNodeID mismatch: got %q, want %q", back.DstNodeID, orig.DstNodeID)
+    }
+    if back.Priority != orig.Priority {
+        t.Errorf("Priority mismatch: got %d, want %d", back.Priority, orig.Priority)
+    }
+    if back.AllowPartnerResources != orig.AllowPartnerResources {
+        t.Errorf("AllowPartnerResources mismatch: got %v, want %v", back.AllowPartnerResources, orig.AllowPartnerResources)
+    }
+    if back.IsDisruptionTolerant != orig.IsDisruptionTolerant {
+        t.Errorf("IsDisruptionTolerant mismatch: got %v, want %v", back.IsDisruptionTolerant, orig.IsDisruptionTolerant)
+    }
+
+    if len(back.FlowRequirements) != 1 {
+        t.Fatalf("expected 1 flow requirement, got %d", len(back.FlowRequirements))
+    }
+
+    got := back.FlowRequirements[0]
+    want := orig.FlowRequirements[0]
+
+    if diff := math.Abs(got.RequestedBandwidthMbps - want.RequestedBandwidthMbps); diff > 1e-6 {
+        t.Errorf("RequestedBandwidth mismatch: got %f, want %f", got.RequestedBandwidthMbps, want.RequestedBandwidthMbps)
+    }
+    if diff := math.Abs(got.MinBandwidthMbps - want.MinBandwidthMbps); diff > 1e-6 {
+        t.Errorf("MinBandwidth mismatch: got %f, want %f", got.MinBandwidthMbps, want.MinBandwidthMbps)
+    }
+    if diff := math.Abs(got.MaxLatencyMs - want.MaxLatencyMs); diff > 1e-6 {
+        t.Errorf("MaxLatencyMs mismatch: got %f, want %f", got.MaxLatencyMs, want.MaxLatencyMs)
+    }
+    if got.ValidFromUnixSec != want.ValidFromUnixSec {
+        t.Errorf("ValidFromUnixSec mismatch: got %d, want %d", got.ValidFromUnixSec, want.ValidFromUnixSec)
+    }
+    if got.ValidToUnixSec != want.ValidToUnixSec {
+        t.Errorf("ValidToUnixSec mismatch: got %d, want %d", got.ValidToUnixSec, want.ValidToUnixSec)
+    }
+}

--- a/model/servicerequest.go
+++ b/model/servicerequest.go
@@ -1,41 +1,35 @@
+// model/servicerequest.go
+
 package model
 
-// ServiceRequest describes a request to provision a network flow between two
-// nodes, along with QoS / timing constraints.
-//
-// This mirrors the intent of Aalyria's ServiceRequest proto but is simplified
-// for the simulator domain model.
 type ServiceRequest struct {
-	ID        string
-	SrcNodeID string
-	DstNodeID string
+    // ID is the simulator's stable identifier for this request.
+    // It is intended to be unique within a Scenario and is what
+    // the NBI layer will use as `request_id` in CRUD operations.
+    ID string
 
-	FlowRequirements []FlowRequirement
+    // Type is a human-readable classification / label for this request
+    // (e.g. "video", "backhaul"), and maps directly to the Aalyria
+    // ServiceRequest.type field in the proto.
+    Type string
 
-	// Higher value => higher priority.
-	Priority int32
+    SrcNodeID             string
+    DstNodeID             string
+    FlowRequirements      []FlowRequirement
+    Priority              int32
+    IsDisruptionTolerant  bool
+    AllowPartnerResources bool
 
-	// Whether this flow can tolerate temporary disruptions.
-	IsDisruptionTolerant bool
-
-	// Whether resources from partner networks may be used.
-	AllowPartnerResources bool
-
-	// Future: status / scheduling details.
-	// IsProvisionedNow     bool
-	// ProvisionedIntervals []TimeInterval
+    // status fields for future scopes, e.g.:
+    // IsProvisionedNow    bool
+    // ProvisionedIntervals []TimeInterval
 }
 
-// FlowRequirement captures basic QoS constraints for a single flow.
 type FlowRequirement struct {
-	// Requested and minimum acceptable bandwidth (in Mbps, for example).
-	RequestedBandwidthMbps float64
-	MinBandwidthMbps       float64
-
-	// Maximum acceptable one-way latency in milliseconds.
-	MaxLatencyMs float64
-
-	// Optional validity window; zero values can mean "always valid".
-	ValidFromUnixSec int64
-	ValidToUnixSec   int64
+    RequestedBandwidthMbps float64
+    MinBandwidthMbps       float64
+    MaxLatencyMs           float64
+    ValidFromUnixSec       int64
+    ValidToUnixSec         int64
+    // (we can add per-flow DTN flags later if needed)
 }


### PR DESCRIPTION
- Add Type field to model.ServiceRequest and separate it from internal ID
- Implement InterfaceFromProto/InterfaceToProto in nbi/types
- Implement LinkFromProto/LinkToProto with node/iface "<->" ID convention
- Implement ServiceRequestFromProto/ServiceRequestToProto using Type ↔ proto.type
- Add roundtrip tests for interfaces, links, and service requests
- Ensure go test ./... passes