### PR TITLE
Add ScenarioState facade for physical and network KBs

### DIFF
--- a/internal/sim/state/state.go
+++ b/internal/sim/state/state.go
@@ -1,0 +1,63 @@
+// internal/sim/state/state.go
+package state
+
+import (
+	"sync"
+
+	network "github.com/signalsfoundry/constellation-simulator/core"
+	"github.com/signalsfoundry/constellation-simulator/kb"
+	"github.com/signalsfoundry/constellation-simulator/model"
+)
+
+// ScenarioState coordinates the simulator's major knowledge bases and
+// holds transient NBI state like ServiceRequests.
+type ScenarioState struct {
+	mu sync.RWMutex
+
+	// physKB is the Scope-1 knowledge base for platforms and nodes.
+	physKB *kb.KnowledgeBase
+
+	// netKB is the Scope-2 knowledge base for interfaces and links.
+	netKB *network.KnowledgeBase
+
+	// serviceRequests is an in-memory store of active ServiceRequests,
+	// keyed by their internal ID.
+	serviceRequests map[string]*model.ServiceRequest
+}
+
+// NewScenarioState wires together the scope-1 and scope-2 knowledge bases
+// and prepares an empty ServiceRequest store.
+func NewScenarioState(phys *kb.KnowledgeBase, net *network.KnowledgeBase) *ScenarioState {
+	return &ScenarioState{
+		physKB:          phys,
+		netKB:           net,
+		serviceRequests: make(map[string]*model.ServiceRequest),
+	}
+}
+
+// PhysicalKB exposes the scope-1 knowledge base for platforms/nodes.
+func (s *ScenarioState) PhysicalKB() *kb.KnowledgeBase {
+	return s.physKB
+}
+
+// NetworkKB exposes the scope-2 knowledge base for interfaces/links.
+func (s *ScenarioState) NetworkKB() *network.KnowledgeBase {
+	return s.netKB
+}
+
+// ServiceRequests returns a snapshot of all stored ServiceRequests.
+//
+// The returned slice is a shallow copy of the internal map values.
+// Callers MUST treat the returned ServiceRequests as read-only and
+// perform any mutations via ScenarioState methods (to be added in
+// later Scope-3 chunks).
+func (s *ScenarioState) ServiceRequests() []*model.ServiceRequest {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]*model.ServiceRequest, 0, len(s.serviceRequests))
+	for _, sr := range s.serviceRequests {
+		out = append(out, sr)
+	}
+	return out
+}


### PR DESCRIPTION
- Introduce internal/sim/state package with ScenarioState struct
- Wire in scope-1 (kb.KnowledgeBase) and scope-2 (network.KnowledgeBase) references
- Add in-memory ServiceRequest store with RWMutex for concurrency
- Expose PhysicalKB, NetworkKB, and read-only ServiceRequests() snapshot