### PR TITLE
sim/state: add ScenarioState platform CRUD backed by KB sentinels

### DIFF
--- a/internal/sim/state/state.go
+++ b/internal/sim/state/state.go
@@ -2,11 +2,21 @@
 package state
 
 import (
+	"errors"
 	"sync"
 
 	network "github.com/signalsfoundry/constellation-simulator/core"
 	"github.com/signalsfoundry/constellation-simulator/kb"
 	"github.com/signalsfoundry/constellation-simulator/model"
+)
+
+// Re-export platform sentinel errors so callers can depend on state.*
+// instead of kb.* directly if they want to.
+var (
+	// ErrPlatformExists indicates a platform already exists.
+	ErrPlatformExists = kb.ErrPlatformExists
+	// ErrPlatformNotFound indicates a requested platform was not found.
+	ErrPlatformNotFound = kb.ErrPlatformNotFound
 )
 
 // ScenarioState coordinates the simulator's major knowledge bases and
@@ -43,6 +53,78 @@ func (s *ScenarioState) PhysicalKB() *kb.KnowledgeBase {
 // NetworkKB exposes the scope-2 knowledge base for interfaces/links.
 func (s *ScenarioState) NetworkKB() *network.KnowledgeBase {
 	return s.netKB
+}
+
+// CreatePlatform inserts a new platform into the scenario.
+func (s *ScenarioState) CreatePlatform(pd *model.PlatformDefinition) error {
+	if pd == nil {
+		return errors.New("platform is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.physKB.AddPlatform(pd); err != nil {
+		if errors.Is(err, kb.ErrPlatformExists) {
+			return ErrPlatformExists
+		}
+		return err
+	}
+	return nil
+}
+
+// GetPlatform retrieves a platform by ID.
+func (s *ScenarioState) GetPlatform(id string) (*model.PlatformDefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	p := s.physKB.GetPlatform(id)
+	if p == nil {
+		return nil, ErrPlatformNotFound
+	}
+	return p, nil
+}
+
+// ListPlatforms returns all platforms in the scenario.
+func (s *ScenarioState) ListPlatforms() []*model.PlatformDefinition {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.physKB.ListPlatforms()
+}
+
+// UpdatePlatform replaces an existing platform entry.
+func (s *ScenarioState) UpdatePlatform(pd *model.PlatformDefinition) error {
+	if pd == nil {
+		return errors.New("platform is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.physKB.UpdatePlatform(pd); err != nil {
+		if errors.Is(err, kb.ErrPlatformNotFound) {
+			return ErrPlatformNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// DeletePlatform removes a platform by ID.
+//
+// NOTE: Referential integrity (nodes referencing this platform) is *not*
+// enforced here yet; that will be handled in later validation/RI chunks.
+func (s *ScenarioState) DeletePlatform(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.physKB.DeletePlatform(id); err != nil {
+		if errors.Is(err, kb.ErrPlatformNotFound) {
+			return ErrPlatformNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 // ServiceRequests returns a snapshot of all stored ServiceRequests.

--- a/internal/sim/state/state_platform_test.go
+++ b/internal/sim/state/state_platform_test.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"errors"
+	"testing"
+
+	network "github.com/signalsfoundry/constellation-simulator/core"
+	"github.com/signalsfoundry/constellation-simulator/kb"
+	"github.com/signalsfoundry/constellation-simulator/model"
+)
+
+func TestScenarioStatePlatformCRUD(t *testing.T) {
+	phys := kb.NewKnowledgeBase()
+	net := network.NewKnowledgeBase()
+	s := NewScenarioState(phys, net)
+
+	p := &model.PlatformDefinition{ID: "p1", Name: "one"}
+	if err := s.CreatePlatform(p); err != nil {
+		t.Fatalf("CreatePlatform error: %v", err)
+	}
+
+	if err := s.CreatePlatform(p); !errors.Is(err, ErrPlatformExists) {
+		t.Fatalf("CreatePlatform duplicate error = %v, want ErrPlatformExists", err)
+	}
+
+	if got, err := s.GetPlatform("p1"); err != nil || got.Name != "one" {
+		t.Fatalf("GetPlatform got (%#v, %v), want name=one", got, err)
+	}
+
+	if list := s.ListPlatforms(); len(list) != 1 || list[0].ID != "p1" {
+		t.Fatalf("ListPlatforms = %#v, want single p1", list)
+	}
+
+	updated := &model.PlatformDefinition{ID: "p1", Name: "updated"}
+	if err := s.UpdatePlatform(updated); err != nil {
+		t.Fatalf("UpdatePlatform error: %v", err)
+	}
+	if got, err := s.GetPlatform("p1"); err != nil || got.Name != "updated" {
+		t.Fatalf("GetPlatform after update got (%#v, %v), want name=updated", got, err)
+	}
+
+	if err := s.DeletePlatform("p1"); err != nil {
+		t.Fatalf("DeletePlatform error: %v", err)
+	}
+
+	if _, err := s.GetPlatform("p1"); !errors.Is(err, ErrPlatformNotFound) {
+		t.Fatalf("GetPlatform after delete error = %v, want ErrPlatformNotFound", err)
+	}
+
+	if err := s.DeletePlatform("p1"); !errors.Is(err, ErrPlatformNotFound) {
+		t.Fatalf("DeletePlatform missing error = %v, want ErrPlatformNotFound", err)
+	}
+}


### PR DESCRIPTION
- Introduce ErrPlatformExists and ErrPlatformNotFound in kb package
- Implement Add/Update/DeletePlatform on kb.KnowledgeBase using sentinel errors
- Add ScenarioState platform CRUD methods (Create/Get/List/Update/Delete) delegating to the Scope-1 KnowledgeBase with RWMutex protection
- Re-export platform sentinel errors from state package
- Implement state_platform_test.go to exercise ScenarioState platform CRUD