### PR TITLE
Wire PlatformService into motion model and fix module deps

### DIFF
--- a/core/motion_test.go
+++ b/core/motion_test.go
@@ -49,3 +49,64 @@ func TestOrbitalSGP4MotionModel_ChangesOverTime(t *testing.T) {
 		t.Fatalf("expected orbital position to change over time, got %+v at both times", first)
 	}
 }
+
+func TestMotionModel_AddUpdateAndRemove(t *testing.T) {
+	tle1 := "1 25544U 98067A   21275.59097222  .00000204  00000-0  10270-4 0  9990"
+	tle2 := "2 25544  51.6459 115.9059 0001817  61.3028  35.9198 15.49370953257760"
+
+	sat := &model.PlatformDefinition{
+		ID:           "sat1",
+		MotionSource: model.MotionSourceSpacetrack,
+	}
+	ground := &model.PlatformDefinition{
+		ID:           "ground1",
+		MotionSource: model.MotionSourceUnknown,
+		Coordinates:  model.Motion{X: 1, Y: 2, Z: 3},
+	}
+
+	mm := NewMotionModel(WithTLEFetcher(func(pd *model.PlatformDefinition) (string, string) {
+		if pd.ID == sat.ID {
+			return tle1, tle2
+		}
+		return "", ""
+	}))
+
+	if err := mm.AddPlatform(sat); err != nil {
+		t.Fatalf("AddPlatform sat: %v", err)
+	}
+	if err := mm.AddPlatform(ground); err != nil {
+		t.Fatalf("AddPlatform ground: %v", err)
+	}
+	if err := mm.AddPlatform(sat); err == nil {
+		t.Fatalf("expected duplicate AddPlatform error")
+	}
+
+	t1 := time.Date(2021, 10, 2, 0, 0, 0, 0, time.UTC)
+	if err := mm.UpdatePositions(t1); err != nil {
+		t.Fatalf("UpdatePositions first tick: %v", err)
+	}
+	firstSat := sat.Coordinates
+	firstGround := ground.Coordinates
+
+	t2 := t1.Add(5 * time.Minute)
+	if err := mm.UpdatePositions(t2); err != nil {
+		t.Fatalf("UpdatePositions second tick: %v", err)
+	}
+	if firstSat == sat.Coordinates {
+		t.Fatalf("expected satellite position to change after UpdatePositions, got %+v", sat.Coordinates)
+	}
+	if firstGround != ground.Coordinates {
+		t.Fatalf("static platform coordinates should stay constant, got %+v", ground.Coordinates)
+	}
+
+	if err := mm.RemovePlatform(ground.ID); err != nil {
+		t.Fatalf("RemovePlatform: %v", err)
+	}
+	ground.Coordinates = model.Motion{X: 9, Y: 9, Z: 9}
+	if err := mm.UpdatePositions(t2.Add(time.Minute)); err != nil {
+		t.Fatalf("UpdatePositions after removal: %v", err)
+	}
+	if ground.Coordinates != (model.Motion{X: 9, Y: 9, Z: 9}) {
+		t.Fatalf("removed platform should not be updated, got %+v", ground.Coordinates)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,17 @@ toolchain go1.24.10
 require (
 	aalyria.com/spacetime v0.0.0
 	github.com/joshuaferrara/go-satellite v0.0.0-20220611180459-512638c64e5b
+	google.golang.org/grpc v1.77.0
+	google.golang.org/protobuf v1.36.10
 )
 
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	google.golang.org/genproto v0.0.0-20251124214823-79d6a2a48846 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846 // indirect
-	google.golang.org/grpc v1.77.0 // indirect
 	golang.org/x/net v0.46.1-0.20251013234738-63d1a5100f82 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
-	google.golang.org/protobuf v1.36.10
 )
 
 replace aalyria.com/spacetime v0.0.0 => ./internal/genproto/aalyria

--- a/internal/nbi/platform_service_test.go
+++ b/internal/nbi/platform_service_test.go
@@ -1,0 +1,156 @@
+package nbi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	common "aalyria.com/spacetime/api/common"
+	v1alpha "aalyria.com/spacetime/api/nbi/v1alpha"
+	"github.com/signalsfoundry/constellation-simulator/core"
+	sim "github.com/signalsfoundry/constellation-simulator/internal/sim/state"
+	"github.com/signalsfoundry/constellation-simulator/kb"
+	"github.com/signalsfoundry/constellation-simulator/model"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeMotionModel struct {
+	added     []string
+	removed   []string
+	addErr    error
+	removeErr error
+}
+
+func (f *fakeMotionModel) AddPlatform(pd *model.PlatformDefinition) error {
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.added = append(f.added, pd.ID)
+	return nil
+}
+
+func (f *fakeMotionModel) RemovePlatform(platformID string) error {
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	f.removed = append(f.removed, platformID)
+	return nil
+}
+
+func newScenarioStateForTest() *sim.ScenarioState {
+	return sim.NewScenarioState(kb.NewKnowledgeBase(), core.NewKnowledgeBase())
+}
+
+func TestCreatePlatformRegistersMotionModel(t *testing.T) {
+	motion := &fakeMotionModel{}
+	svc := NewPlatformService(newScenarioStateForTest(), motion, nil)
+
+	name := "platform-1"
+	typ := "SATELLITE"
+	ms := common.PlatformDefinition_SPACETRACK_ORG
+
+	resp, err := svc.CreatePlatform(context.Background(), &common.PlatformDefinition{
+		Name:         &name,
+		Type:         &typ,
+		MotionSource: &ms,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlatform error: %v", err)
+	}
+
+	// Proto round-trip sanity: name should match.
+	if resp.GetName() != name {
+		t.Fatalf("unexpected platform name in response: %s", resp.GetName())
+	}
+
+	// We don’t have an ID field on the proto, so read from ScenarioState.
+	plats := svc.state.ListPlatforms()
+	if len(plats) != 1 {
+		t.Fatalf("expected exactly 1 platform in state, got %d", len(plats))
+	}
+	id := plats[0].ID
+	if id == "" {
+		t.Fatalf("expected platform in state to have a non-empty ID")
+	}
+
+	if len(motion.added) != 1 {
+		t.Fatalf("expected motion model registration for one platform, got %d", len(motion.added))
+	}
+	if motion.added[0] != id {
+		t.Fatalf("expected motion model registration for id %q, got %q", id, motion.added[0])
+	}
+}
+
+func TestCreatePlatformMotionModelErrorRollsBack(t *testing.T) {
+	motion := &fakeMotionModel{addErr: errors.New("motion failure")}
+	svc := NewPlatformService(newScenarioStateForTest(), motion, nil)
+
+	name := "platform-2"
+	typ := "SATELLITE"
+
+	_, err := svc.CreatePlatform(context.Background(), &common.PlatformDefinition{
+		Name: &name,
+		Type: &typ,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error from motion model failure, got %v", err)
+	}
+
+	// We don’t know the generated ID on failure, but we *do* know that
+	// there should be no platforms left in state.
+	if plats := svc.state.ListPlatforms(); len(plats) != 0 {
+		t.Fatalf("expected no platforms in state after rollback, got %d", len(plats))
+	}
+}
+
+func TestDeletePlatformUnregistersMotionModel(t *testing.T) {
+	motion := &fakeMotionModel{}
+	state := newScenarioStateForTest()
+	if err := state.CreatePlatform(&model.PlatformDefinition{
+		ID:   "platform-3",
+		Name: "platform-3",
+		Type: "SATELLITE",
+	}); err != nil {
+		t.Fatalf("seed platform error: %v", err)
+	}
+
+	svc := NewPlatformService(state, motion, nil)
+	pid := "platform-3"
+	if _, err := svc.DeletePlatform(context.Background(), &v1alpha.DeletePlatformRequest{
+		PlatformId: &pid,
+	}); err != nil {
+		t.Fatalf("DeletePlatform error: %v", err)
+	}
+
+	if len(motion.removed) != 1 || motion.removed[0] != "platform-3" {
+		t.Fatalf("expected motion removal for platform-3, got %#v", motion.removed)
+	}
+	if _, err := state.GetPlatform("platform-3"); !errors.Is(err, sim.ErrPlatformNotFound) {
+		t.Fatalf("platform should be removed from state, err=%v", err)
+	}
+}
+
+func TestDeletePlatformMotionModelError(t *testing.T) {
+	motion := &fakeMotionModel{removeErr: errors.New("cannot remove")}
+	state := newScenarioStateForTest()
+	if err := state.CreatePlatform(&model.PlatformDefinition{
+		ID:   "platform-4",
+		Name: "platform-4",
+		Type: "SATELLITE",
+	}); err != nil {
+		t.Fatalf("seed platform error: %v", err)
+	}
+
+	svc := NewPlatformService(state, motion, nil)
+	pid := "platform-4"
+	_, err := svc.DeletePlatform(context.Background(), &v1alpha.DeletePlatformRequest{
+		PlatformId: &pid,
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error when motion removal fails, got %v", err)
+	}
+	if _, err := state.GetPlatform("platform-4"); !errors.Is(err, sim.ErrPlatformNotFound) {
+		t.Fatalf("platform should already be removed from state despite motion error, err=%v", err)
+	}
+}


### PR DESCRIPTION
- Integrate PlatformService with ScenarioState and MotionModel for platform CRUD
- Register/unregister platforms in MotionModel on CreatePlatform/DeletePlatform
- Add MotionModel add/remove APIs and unit tests for dynamic platform motion
- Fix PlatformService tests to assert IDs via ScenarioState instead of proto fields
- Mark google.golang.org/grpc and google.golang.org/protobuf as direct dependencies in go.mod