### PR TITLE
Implement ServiceRequestService backed by ScenarioState

### DIFF
--- a/internal/nbi/servicerequest_service.go
+++ b/internal/nbi/servicerequest_service.go
@@ -1,0 +1,258 @@
+// internal/nbi/servicerequest_service.go
+package nbi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	v1alpha "aalyria.com/spacetime/api/nbi/v1alpha"
+	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	"github.com/signalsfoundry/constellation-simulator/internal/nbi/types"
+	sim "github.com/signalsfoundry/constellation-simulator/internal/sim/state"
+	"github.com/signalsfoundry/constellation-simulator/model"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ServiceRequestService implements the ServiceRequestService gRPC server backed
+// by a ScenarioState instance.
+type ServiceRequestService struct {
+	v1alpha.UnimplementedServiceRequestServiceServer
+
+	state *sim.ScenarioState
+	log   Logger
+}
+
+// NewServiceRequestService constructs a ServiceRequestService bound to ScenarioState.
+func NewServiceRequestService(state *sim.ScenarioState, log Logger) *ServiceRequestService {
+	return &ServiceRequestService{
+		state: state,
+		log:   log,
+	}
+}
+
+// CreateServiceRequest stores a new ServiceRequest after validation.
+func (s *ServiceRequestService) CreateServiceRequest(
+	ctx context.Context,
+	in *resources.ServiceRequest,
+) (*resources.ServiceRequest, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	if in == nil {
+		return nil, status.Error(codes.InvalidArgument, "service_request is required")
+	}
+
+	dom, err := types.ServiceRequestFromProto(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// The Aalyria ServiceRequest proto does not expose a dedicated ID field.
+	// For now we use the `type` string as a stable identifier for CRUD
+	// operations, and generate one if it is absent.
+	dom.ID = in.GetType()
+	if dom.ID == "" {
+		dom.ID = generateServiceRequestID()
+	}
+
+	if err := s.validateServiceRequest(dom); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if err := s.state.CreateServiceRequest(dom); err != nil {
+		switch {
+		case errors.Is(err, sim.ErrServiceRequestExists):
+			return nil, status.Error(codes.AlreadyExists, err.Error())
+		default:
+			if s.log != nil {
+				s.log.Errorw("CreateServiceRequest failed", "err", err)
+			}
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+	}
+
+	return attachServiceRequestID(types.ServiceRequestToProto(dom), dom.ID), nil
+}
+
+// GetServiceRequest retrieves a ServiceRequest by ID.
+func (s *ServiceRequestService) GetServiceRequest(
+	ctx context.Context,
+	req *v1alpha.GetServiceRequestRequest,
+) (*resources.ServiceRequest, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	if req == nil || req.GetServiceRequestId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "service_request_id is required")
+	}
+
+	sr, err := s.state.GetServiceRequest(req.GetServiceRequestId())
+	if err != nil {
+		if errors.Is(err, sim.ErrServiceRequestNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return attachServiceRequestID(types.ServiceRequestToProto(sr), sr.ID), nil
+}
+
+// ListServiceRequests returns all stored ServiceRequests.
+func (s *ServiceRequestService) ListServiceRequests(
+	ctx context.Context,
+	_ *v1alpha.ListServiceRequestsRequest,
+) (*v1alpha.ListServiceRequestsResponse, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+
+	resp := &v1alpha.ListServiceRequestsResponse{}
+	for _, sr := range s.state.ListServiceRequests() {
+		resp.ServiceRequests = append(resp.ServiceRequests, attachServiceRequestID(
+			types.ServiceRequestToProto(sr),
+			sr.ID,
+		))
+	}
+	return resp, nil
+}
+
+// UpdateServiceRequest replaces an existing ServiceRequest entry.
+func (s *ServiceRequestService) UpdateServiceRequest(
+	ctx context.Context,
+	req *v1alpha.UpdateServiceRequestRequest,
+) (*resources.ServiceRequest, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	if req == nil || req.GetServiceRequest() == nil {
+		return nil, status.Error(codes.InvalidArgument, "service_request is required")
+	}
+
+	dom, err := types.ServiceRequestFromProto(req.GetServiceRequest())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// ID is carried via the proto's `type` field for now.
+	dom.ID = req.GetServiceRequest().GetType()
+	if dom.ID == "" {
+		return nil, status.Error(codes.InvalidArgument, "service_request_id is required")
+	}
+
+	existing, err := s.state.GetServiceRequest(dom.ID)
+	if err != nil {
+		if errors.Is(err, sim.ErrServiceRequestNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	// If in future we have a separate ID path parameter, enforce that it
+	// matches the existing ID; for now this is just a sanity check.
+	if existing.ID != dom.ID {
+		return nil, status.Error(codes.InvalidArgument, "service_request_id cannot be changed")
+	}
+
+	if err := s.validateServiceRequest(dom); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if err := s.state.UpdateServiceRequest(dom); err != nil {
+		if errors.Is(err, sim.ErrServiceRequestNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return attachServiceRequestID(types.ServiceRequestToProto(dom), dom.ID), nil
+}
+
+// DeleteServiceRequest removes a ServiceRequest by ID.
+func (s *ServiceRequestService) DeleteServiceRequest(
+	ctx context.Context,
+	req *v1alpha.DeleteServiceRequestRequest,
+) (*emptypb.Empty, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	if req == nil || req.GetServiceRequestId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "service_request_id is required")
+	}
+
+	if err := s.state.DeleteServiceRequest(req.GetServiceRequestId()); err != nil {
+		if errors.Is(err, sim.ErrServiceRequestNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+// ensureReady verifies the service has been constructed correctly.
+func (s *ServiceRequestService) ensureReady() error {
+	if s == nil || s.state == nil {
+		return status.Error(codes.FailedPrecondition, "scenario state is not configured")
+	}
+	return nil
+}
+
+// validateServiceRequest performs basic sanity checks and referential integrity.
+func (s *ServiceRequestService) validateServiceRequest(sr *model.ServiceRequest) error {
+	if sr == nil {
+		return errors.New("service request is required")
+	}
+	if sr.ID == "" {
+		return errors.New("service_request_id is required")
+	}
+	if sr.SrcNodeID == "" || sr.DstNodeID == "" {
+		return errors.New("src_node_id and dst_node_id are required")
+	}
+
+	phys := s.state.PhysicalKB()
+	if phys.GetNetworkNode(sr.SrcNodeID) == nil {
+		return fmt.Errorf("%w: %q", sim.ErrNodeNotFound, sr.SrcNodeID)
+	}
+	if phys.GetNetworkNode(sr.DstNodeID) == nil {
+		return fmt.Errorf("%w: %q", sim.ErrNodeNotFound, sr.DstNodeID)
+	}
+
+	if len(sr.FlowRequirements) == 0 {
+		return errors.New("at least one flow requirement is required")
+	}
+	for i, fr := range sr.FlowRequirements {
+		if fr.RequestedBandwidth < 0 {
+			return fmt.Errorf("flow requirement %d requested bandwidth cannot be negative", i)
+		}
+		if fr.MinBandwidth < 0 {
+			return fmt.Errorf("flow requirement %d minimum bandwidth cannot be negative", i)
+		}
+		if fr.MaxLatency < 0 {
+			return fmt.Errorf("flow requirement %d latency cannot be negative", i)
+		}
+		if !fr.ValidFrom.IsZero() && !fr.ValidTo.IsZero() && fr.ValidTo.Before(fr.ValidFrom) {
+			return fmt.Errorf("flow requirement %d has invalid time interval: end before start", i)
+		}
+	}
+
+	return nil
+}
+
+func generateServiceRequestID() string {
+	return fmt.Sprintf("sr-%d", time.Now().UnixNano())
+}
+
+// attachServiceRequestID mirrors the internal ID onto the proto `type` field so
+// callers can read the stable identifier until the proto grows an explicit ID.
+func attachServiceRequestID(p *resources.ServiceRequest, id string) *resources.ServiceRequest {
+	if p == nil {
+		return nil
+	}
+	if id != "" {
+		p.Type = &id
+	}
+	return p
+}

--- a/internal/nbi/servicerequest_service_test.go
+++ b/internal/nbi/servicerequest_service_test.go
@@ -1,0 +1,345 @@
+// internal/nbi/servicerequest_service_test.go
+package nbi
+
+import (
+	"context"
+	"testing"
+
+	v1alpha "aalyria.com/spacetime/api/nbi/v1alpha"
+	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	sim "github.com/signalsfoundry/constellation-simulator/internal/sim/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// newServiceRequestServiceForTest wires up a ServiceRequestService with an
+// in-memory ScenarioState.
+func newServiceRequestServiceForTest() (*ServiceRequestService, *sim.ScenarioState) {
+	state := newScenarioStateForTest()
+	return NewServiceRequestService(state, nil), state
+}
+
+func flowReq(bps float64) *resources.ServiceRequest_FlowRequirements {
+	return &resources.ServiceRequest_FlowRequirements{
+		BandwidthBpsRequested: &bps,
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+// -----------------------------------------------------------------------------
+// CreateServiceRequest
+// -----------------------------------------------------------------------------
+
+func TestServiceRequestServiceCreate(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+
+	addNodeWithInterface(t, state, "src-node")
+	addNodeWithInterface(t, state, "dst-node")
+
+	id := "sr-create"
+	bandwidthBps := 1_000_000.0
+	req := &resources.ServiceRequest{
+		Type:    &id,
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src-node"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst-node"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{BandwidthBpsRequested: &bandwidthBps},
+		},
+	}
+
+	resp, err := svc.CreateServiceRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreateServiceRequest error: %v", err)
+	}
+	if resp.GetType() != id {
+		t.Fatalf("CreateServiceRequest response Type = %q, want %q", resp.GetType(), id)
+	}
+
+	stored, err := state.GetServiceRequest(id)
+	if err != nil {
+		t.Fatalf("state.GetServiceRequest error: %v", err)
+	}
+	if stored.SrcNodeID != "src-node" || stored.DstNodeID != "dst-node" {
+		t.Fatalf("stored ServiceRequest endpoints = (%s, %s), want (src-node, dst-node)", stored.SrcNodeID, stored.DstNodeID)
+	}
+	if len(stored.FlowRequirements) != 1 {
+		t.Fatalf("stored FlowRequirements length = %d, want 1", len(stored.FlowRequirements))
+	}
+	if got, want := stored.FlowRequirements[0].RequestedBandwidth, bandwidthBps; got != want {
+		t.Fatalf("stored FlowRequirements[0].RequestedBandwidth = %f, want %f", got, want)
+	}
+}
+
+func TestServiceRequestServiceCreateGeneratesID(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+
+	addNodeWithInterface(t, state, "node-a")
+	addNodeWithInterface(t, state, "node-b")
+
+	req := &resources.ServiceRequest{
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			flowReq(500_000), // 500 kbps
+		},
+	}
+
+	resp, err := svc.CreateServiceRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreateServiceRequest error: %v", err)
+	}
+	if resp.GetType() == "" {
+		t.Fatalf("CreateServiceRequest response Type should carry generated ID")
+	}
+
+	if _, err := state.GetServiceRequest(resp.GetType()); err != nil {
+		t.Fatalf("GetServiceRequest(generated) error: %v", err)
+	}
+}
+
+func TestServiceRequestServiceCreateValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *resources.ServiceRequest
+	}{
+		{
+			name: "missing src node",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "missing"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					flowReq(1_000_000),
+				},
+			},
+		},
+		{
+			name: "no flow requirements",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+			},
+		},
+		{
+			name: "negative bandwidth",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					flowReq(-1),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, state := newServiceRequestServiceForTest()
+			// Seed nodes so only the intended validation triggers when applicable.
+			addNodeWithInterface(t, state, "src")
+			addNodeWithInterface(t, state, "dst")
+
+			_, err := svc.CreateServiceRequest(context.Background(), tc.req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("CreateServiceRequest(%s) code = %v, want InvalidArgument (err=%v)", tc.name, status.Code(err), err)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Get/List
+// -----------------------------------------------------------------------------
+
+func TestServiceRequestServiceGetAndList(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+	addNodeWithInterface(t, state, "node-1")
+	addNodeWithInterface(t, state, "node-2")
+
+	id1 := "sr-1"
+	id2 := "sr-2"
+	for _, id := range []string{id1, id2} {
+		bw := 10_000.0
+		req := &resources.ServiceRequest{
+			Type:    &id,
+			SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-1"},
+			DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-2"},
+			Requirements: []*resources.ServiceRequest_FlowRequirements{
+				{BandwidthBpsRequested: &bw},
+			},
+		}
+		if _, err := svc.CreateServiceRequest(context.Background(), req); err != nil {
+			t.Fatalf("CreateServiceRequest(%s) error: %v", id, err)
+		}
+	}
+
+	getResp, err := svc.GetServiceRequest(context.Background(), &v1alpha.GetServiceRequestRequest{
+		ServiceRequestId: &id1,
+	})
+	if err != nil {
+		t.Fatalf("GetServiceRequest error: %v", err)
+	}
+	if getResp.GetType() != id1 {
+		t.Fatalf("GetServiceRequest Type = %q, want %q", getResp.GetType(), id1)
+	}
+
+	listResp, err := svc.ListServiceRequests(context.Background(), &v1alpha.ListServiceRequestsRequest{})
+	if err != nil {
+		t.Fatalf("ListServiceRequests error: %v", err)
+	}
+	if len(listResp.GetServiceRequests()) != 2 {
+		t.Fatalf("ListServiceRequests count = %d, want 2", len(listResp.GetServiceRequests()))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Update
+// -----------------------------------------------------------------------------
+
+func TestServiceRequestServiceUpdate(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+	addNodeWithInterface(t, state, "node-a")
+	addNodeWithInterface(t, state, "node-b")
+
+	id := "sr-update"
+	initialBps := 100_000.0
+	createReq := &resources.ServiceRequest{
+		Type:    &id,
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{BandwidthBpsRequested: &initialBps},
+		},
+	}
+	if _, err := svc.CreateServiceRequest(context.Background(), createReq); err != nil {
+		t.Fatalf("CreateServiceRequest seed error: %v", err)
+	}
+
+	newBps := 200_000.0
+	updateReq := &v1alpha.UpdateServiceRequestRequest{
+		ServiceRequest: &resources.ServiceRequest{
+			Type:    &id,
+			SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+			DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+			Requirements: []*resources.ServiceRequest_FlowRequirements{
+				{BandwidthBpsRequested: &newBps},
+			},
+			Priority:              floatPtr(5),
+			AllowPartnerResources: boolPtr(true),
+		},
+	}
+
+	if _, err := svc.UpdateServiceRequest(context.Background(), updateReq); err != nil {
+		t.Fatalf("UpdateServiceRequest error: %v", err)
+	}
+
+	stored, err := state.GetServiceRequest(id)
+	if err != nil {
+		t.Fatalf("GetServiceRequest after update error: %v", err)
+	}
+	if stored.Priority != 5 || !stored.AllowPartnerResources {
+		t.Fatalf("stored ServiceRequest after update = %+v, want Priority=5 AllowPartnerResources=true", stored)
+	}
+	if len(stored.FlowRequirements) != 1 {
+		t.Fatalf("stored FlowRequirements length after update = %d, want 1", len(stored.FlowRequirements))
+	}
+	if got, want := stored.FlowRequirements[0].RequestedBandwidth, newBps; got != want {
+		t.Fatalf("stored FlowRequirements after update RequestedBandwidth = %f, want %f", got, want)
+	}
+}
+
+func TestServiceRequestServiceUpdateErrors(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+	addNodeWithInterface(t, state, "node-a")
+	addNodeWithInterface(t, state, "node-b")
+
+	// Seed one ServiceRequest.
+	id := "sr-existing"
+	bw := 1_000_000.0
+	createReq := &resources.ServiceRequest{
+		Type:    &id,
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{BandwidthBpsRequested: &bw},
+		},
+	}
+	if _, err := svc.CreateServiceRequest(context.Background(), createReq); err != nil {
+		t.Fatalf("CreateServiceRequest seed error: %v", err)
+	}
+
+	// Missing ID should be invalid.
+	_, err := svc.UpdateServiceRequest(context.Background(), &v1alpha.UpdateServiceRequestRequest{
+		ServiceRequest: &resources.ServiceRequest{
+			SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+			DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+			Requirements: []*resources.ServiceRequest_FlowRequirements{
+				flowReq(1_000_000),
+			},
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("UpdateServiceRequest missing ID code = %v, want InvalidArgument (err=%v)", status.Code(err), err)
+	}
+
+	// Unknown ID should be NotFound.
+	missing := "sr-missing"
+	_, err = svc.UpdateServiceRequest(context.Background(), &v1alpha.UpdateServiceRequestRequest{
+		ServiceRequest: &resources.ServiceRequest{
+			Type:    &missing,
+			SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+			DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+			Requirements: []*resources.ServiceRequest_FlowRequirements{
+				flowReq(1_000_000),
+			},
+		},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("UpdateServiceRequest missing code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Delete
+// -----------------------------------------------------------------------------
+
+func TestServiceRequestServiceDelete(t *testing.T) {
+	svc, state := newServiceRequestServiceForTest()
+	addNodeWithInterface(t, state, "node-a")
+	addNodeWithInterface(t, state, "node-b")
+
+	id := "sr-delete"
+	bw := 1_000_000.0
+	req := &resources.ServiceRequest{
+		Type:    &id,
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "node-a"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "node-b"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{BandwidthBpsRequested: &bw},
+		},
+	}
+	if _, err := svc.CreateServiceRequest(context.Background(), req); err != nil {
+		t.Fatalf("CreateServiceRequest seed error: %v", err)
+	}
+
+	if _, err := svc.DeleteServiceRequest(context.Background(), &v1alpha.DeleteServiceRequestRequest{
+		ServiceRequestId: &id,
+	}); err != nil {
+		t.Fatalf("DeleteServiceRequest error: %v", err)
+	}
+	if _, err := state.GetServiceRequest(id); err == nil {
+		t.Fatalf("expected service request to be deleted from state")
+	}
+
+	if _, err := svc.DeleteServiceRequest(context.Background(), &v1alpha.DeleteServiceRequestRequest{
+		ServiceRequestId: &id,
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("DeleteServiceRequest second call code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
- Implement ServiceRequestService gRPC server in internal/nbi/servicerequest_service.go
  - Wire Create/Get/List/Update/Delete to ScenarioState ServiceRequest CRUD
  - Use types.ServiceRequestFromProto / ServiceRequestToProto for mapping
  - Carry internal ServiceRequest ID via the proto `type` field (generate if empty)
  - Validate src/dst nodes, presence of flow requirements, and non-negative bandwidth/latency
- Add servicerequest_service_test.go covering:
  - Create with explicit and generated IDs
  - Validation failures (missing nodes, no requirements, negative bandwidth)
  - Get and List roundtrips
  - Update behaviour and error cases
  - Delete semantics and NotFound handling
- Align validation and tests with model.FlowRequirement fields (RequestedBandwidth/MinBandwidth/MaxLatency, ValidFrom/ValidTo) and bps/seconds units