### PR TITLE
Finalize ScenarioState clear/snapshot semantics

### DIFF
--- a/core/connectivity_service.go
+++ b/core/connectivity_service.go
@@ -1,3 +1,4 @@
+// core/connectivity_service.go
 package core
 
 import "math"
@@ -27,6 +28,17 @@ func NewConnectivityService(kb *KnowledgeBase) *ConnectivityService {
 		KB:                    kb,
 		MinElevationDeg:       10.0, // a conservative but typical value
 		DefaultWiredLatencyMs: 5.0,  // milliseconds
+	}
+}
+
+// Reset clears any cached connectivity state so a fresh scenario can be
+// loaded without leftover dynamic links.
+func (cs *ConnectivityService) Reset() {
+	if cs == nil {
+		return
+	}
+	if cs.KB != nil {
+		cs.KB.ClearDynamicWirelessLinks()
 	}
 }
 

--- a/core/motion.go
+++ b/core/motion.go
@@ -1,3 +1,4 @@
+// core/motion.go
 package core
 
 import (
@@ -94,6 +95,14 @@ func (m *MotionModel) RemovePlatform(platformID string) error {
 	}
 	delete(m.entries, platformID)
 	return nil
+}
+
+// Reset clears all registered platforms and their propagators, returning
+// the motion model to an empty state.
+func (m *MotionModel) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = make(map[string]motionEntry)
 }
 
 // UpdatePositions advances all registered platforms to simTime.


### PR DESCRIPTION
Wire ScenarioState to reset MotionModel and ConnectivityService on ClearScenario, and ensure both scope-1 and scope-2 KBs plus in-memory ServiceRequests are fully cleared. Extend Snapshot to return a complete ScenarioSnapshot including interfaces grouped by node. Add tests to verify scenario build → snapshot, ClearScenario side effects, and empty snapshot after clear.