### PR TITLE
Add central validation helpers for NBI entities

### DIFF
--- a/internal/nbi/link_service.go
+++ b/internal/nbi/link_service.go
@@ -46,8 +46,8 @@ func (s *NetworkLinkService) CreateLink(
 	if err := s.ensureReady(); err != nil {
 		return nil, err
 	}
-	if in == nil {
-		return nil, status.Error(codes.InvalidArgument, "link is required")
+	if err := ValidateLinkProto(in); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	links, err := types.BidirectionalLinkFromProto(in)

--- a/internal/nbi/validation.go
+++ b/internal/nbi/validation.go
@@ -1,0 +1,323 @@
+	package nbi
+
+	import (
+		"errors"
+		"fmt"
+		"strings"
+		"time"
+
+		common "aalyria.com/spacetime/api/common"
+		resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	)
+
+	var (
+		ErrInvalidPlatform       = errors.New("invalid platform")
+		ErrInvalidNode           = errors.New("invalid node")
+		ErrInvalidInterface      = errors.New("invalid interface")
+		ErrInvalidLink           = errors.New("invalid link")
+		ErrInvalidServiceRequest = errors.New("invalid service request")
+	)
+
+	// ValidatePlatformProto performs basic structural validation for a platform.
+	func ValidatePlatformProto(pd *common.PlatformDefinition) error {
+		if pd == nil {
+			return fmt.Errorf("%w: platform definition is required", ErrInvalidPlatform)
+		}
+		if strings.TrimSpace(pd.GetName()) == "" {
+			return fmt.Errorf("%w: name (used as ID) is required", ErrInvalidPlatform)
+		}
+		if strings.TrimSpace(pd.GetType()) == "" {
+			return fmt.Errorf("%w: type is required", ErrInvalidPlatform)
+		}
+
+		// Orbital platforms must specify a motion source (e.g. TLE-backed propagation).
+		if strings.EqualFold(pd.GetType(), "SATELLITE") && pd.GetMotionSource() == common.PlatformDefinition_UNKNOWN_SOURCE {
+			return fmt.Errorf("%w: motion source is required for orbital platforms", ErrInvalidPlatform)
+		}
+
+		return nil
+	}
+
+	// ValidateInterfaceProto checks a single interface for required fields.
+	func ValidateInterfaceProto(iface *resources.NetworkInterface) error {
+		if iface == nil {
+			return fmt.Errorf("%w: interface is required", ErrInvalidInterface)
+		}
+		if strings.TrimSpace(iface.GetInterfaceId()) == "" {
+			return fmt.Errorf("%w: interface_id is required", ErrInvalidInterface)
+		}
+
+		switch medium := iface.GetInterfaceMedium().(type) {
+		case *resources.NetworkInterface_Wired:
+			if medium.Wired == nil {
+				return fmt.Errorf("%w: wired interface details are required", ErrInvalidInterface)
+			}
+		case *resources.NetworkInterface_Wireless:
+			if medium.Wireless == nil {
+				return fmt.Errorf("%w: wireless interface details are required", ErrInvalidInterface)
+			}
+			trxID := ""
+			if medium.Wireless.GetTransceiverModelId() != nil {
+				trxID = medium.Wireless.GetTransceiverModelId().GetTransceiverModelId()
+			}
+			if strings.TrimSpace(trxID) == "" {
+				return fmt.Errorf("%w: wireless interface %q missing transceiver_model_id", ErrInvalidInterface, iface.GetInterfaceId())
+			}
+		default:
+			return fmt.Errorf("%w: interface_medium is required", ErrInvalidInterface)
+		}
+
+		return nil
+	}
+
+	// ValidateNodeProto checks a NetworkNode and its embedded interfaces.
+	func ValidateNodeProto(node *resources.NetworkNode) error {
+		if node == nil {
+			return fmt.Errorf("%w: node is required", ErrInvalidNode)
+		}
+		if strings.TrimSpace(node.GetNodeId()) == "" {
+			return fmt.Errorf("%w: node_id is required", ErrInvalidNode)
+		}
+
+		if len(node.GetNodeInterface()) == 0 {
+			return fmt.Errorf("%w: at least one interface is required", ErrInvalidNode)
+		}
+
+		if _, err := platformIDFromInterfaces(node); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidNode, err)
+		}
+
+		seen := make(map[string]struct{}, len(node.GetNodeInterface()))
+		for i, iface := range node.GetNodeInterface() {
+			if iface == nil {
+				return fmt.Errorf("%w: interface[%d] is nil", ErrInvalidNode, i)
+			}
+			if err := ValidateInterfaceProto(iface); err != nil {
+				return fmt.Errorf("%w: interface[%d]: %v", ErrInvalidNode, i, err)
+			}
+
+			parent, local := splitInterfaceRef(iface.GetInterfaceId())
+			if parent != "" && parent != node.GetNodeId() {
+				return fmt.Errorf("%w: interface %q belongs to different node %q", ErrInvalidNode, iface.GetInterfaceId(), parent)
+			}
+			if local == "" {
+				return fmt.Errorf("%w: interface[%d] id is empty", ErrInvalidNode, i)
+			}
+			if _, ok := seen[local]; ok {
+				return fmt.Errorf("%w: duplicate interface_id %q for node %q", ErrInvalidNode, local, node.GetNodeId())
+			}
+			seen[local] = struct{}{}
+		}
+
+		return nil
+	}
+
+	// ValidateLinkProto enforces structural sanity for a bidirectional link.
+	func ValidateLinkProto(link *resources.BidirectionalLink) error {
+		if link == nil {
+			return fmt.Errorf("%w: link is required", ErrInvalidLink)
+		}
+
+		endA := extractBidirectionalEndpoint(
+			link.GetANetworkNodeId(),
+			link.GetATxInterfaceId(),
+			link.GetARxInterfaceId(),
+			link.GetA(),
+		)
+		endB := extractBidirectionalEndpoint(
+			link.GetBNetworkNodeId(),
+			link.GetBTxInterfaceId(),
+			link.GetBRxInterfaceId(),
+			link.GetB(),
+		)
+
+		aIface := normalizeInterfaceRef(endA.nodeID, endA.txInterface())
+		if aIface == "" {
+			aIface = normalizeInterfaceRef(endA.nodeID, endA.rxInterface())
+		}
+		bIface := normalizeInterfaceRef(endB.nodeID, endB.txInterface())
+		if bIface == "" {
+			bIface = normalizeInterfaceRef(endB.nodeID, endB.rxInterface())
+		}
+
+		if aIface == "" || bIface == "" {
+			return fmt.Errorf("%w: both link endpoints must specify node and interface IDs", ErrInvalidLink)
+		}
+		if aIface == bIface {
+			return fmt.Errorf("%w: link endpoints must be distinct", ErrInvalidLink)
+		}
+
+		return nil
+	}
+
+	// ValidateServiceRequestProto checks structural validity for a ServiceRequest.
+	func ValidateServiceRequestProto(sr *resources.ServiceRequest) error {
+		if sr == nil {
+			return fmt.Errorf("%w: service request is required", ErrInvalidServiceRequest)
+		}
+		if strings.TrimSpace(sr.GetSrcNodeId()) == "" || strings.TrimSpace(sr.GetDstNodeId()) == "" {
+			return fmt.Errorf("%w: src_node_id and dst_node_id are required", ErrInvalidServiceRequest)
+		}
+
+		if len(sr.GetRequirements()) == 0 {
+			return fmt.Errorf("%w: at least one flow requirement is required", ErrInvalidServiceRequest)
+		}
+
+		for i, req := range sr.GetRequirements() {
+			if req == nil {
+				return fmt.Errorf("%w: flow requirement %d is nil", ErrInvalidServiceRequest, i)
+			}
+			if req.GetBandwidthBpsRequested() < 0 {
+				return fmt.Errorf("%w: flow requirement %d requested bandwidth cannot be negative", ErrInvalidServiceRequest, i)
+			}
+			if req.GetBandwidthBpsMinimum() < 0 {
+				return fmt.Errorf("%w: flow requirement %d minimum bandwidth cannot be negative", ErrInvalidServiceRequest, i)
+			}
+			if req.GetLatencyMaximum() != nil && req.GetLatencyMaximum().AsDuration() < 0 {
+				return fmt.Errorf("%w: flow requirement %d latency cannot be negative", ErrInvalidServiceRequest, i)
+			}
+			if ti := req.GetTimeInterval(); ti != nil {
+				start := protoTimeToTime(ti.GetStartTime())
+				end := protoTimeToTime(ti.GetEndTime())
+				if !start.IsZero() && !end.IsZero() && end.Before(start) {
+					return fmt.Errorf("%w: flow requirement %d has invalid time interval (end before start)", ErrInvalidServiceRequest, i)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	// platformIDFromInterfaces extracts a single platform_id from the node's
+	// interfaces. If multiple non-empty platform_ids are present and disagree, an
+	// error is returned.
+	func platformIDFromInterfaces(in *resources.NetworkNode) (string, error) {
+		var platformID string
+
+		setOrVerify := func(candidate string) error {
+			if candidate == "" {
+				return nil
+			}
+			if platformID == "" {
+				platformID = candidate
+				return nil
+			}
+			if platformID != candidate {
+				return fmt.Errorf("conflicting platform_id values: %q vs %q", platformID, candidate)
+			}
+			return nil
+		}
+
+		for _, iface := range in.GetNodeInterface() {
+			if iface == nil {
+				continue
+			}
+
+			switch medium := iface.GetInterfaceMedium().(type) {
+			case *resources.NetworkInterface_Wired:
+				if medium.Wired != nil {
+					if err := setOrVerify(medium.Wired.GetPlatformId()); err != nil {
+						return "", err
+					}
+				}
+			case *resources.NetworkInterface_Wireless:
+				if medium.Wireless != nil {
+					if err := setOrVerify(medium.Wireless.GetPlatform()); err != nil {
+						return "", err
+					}
+				}
+			}
+		}
+
+		return platformID, nil
+	}
+
+	func interfacePlatformID(iface *resources.NetworkInterface) string {
+		switch medium := iface.GetInterfaceMedium().(type) {
+		case *resources.NetworkInterface_Wired:
+			if medium.Wired != nil {
+				return medium.Wired.GetPlatformId()
+			}
+		case *resources.NetworkInterface_Wireless:
+			if medium.Wireless != nil {
+				return medium.Wireless.GetPlatform()
+			}
+		}
+		return ""
+	}
+
+	func splitInterfaceRef(ref string) (string, string) {
+		parts := strings.SplitN(ref, "/", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1]
+		}
+		return "", ref
+	}
+
+	// normalizeInterfaceRef ensures we have a "node/iface" form.
+	// If nodeID is empty, it will be inferred from ifaceID if possible.
+	func normalizeInterfaceRef(nodeID, ifaceID string) string {
+		if nodeID == "" {
+			if n, local := splitInterfaceRef(ifaceID); n != "" {
+				nodeID = n
+				ifaceID = local
+			}
+		}
+		switch {
+		case nodeID == "" && ifaceID == "":
+			return ""
+		case nodeID == "":
+			return ifaceID
+		case ifaceID == "":
+			return nodeID
+		default:
+			return nodeID + "/" + ifaceID
+		}
+	}
+
+	type bidirectionalEndpoint struct {
+		nodeID string
+		txID   string
+		rxID   string
+	}
+
+	func extractBidirectionalEndpoint(nodeID, txID, rxID string, end *resources.LinkEnd) bidirectionalEndpoint {
+		if end != nil && end.Id != nil {
+			if nodeID == "" {
+				nodeID = end.Id.GetNodeId()
+			}
+			if txID == "" {
+				txID = end.Id.GetInterfaceId()
+			}
+			if rxID == "" {
+				rxID = end.Id.GetInterfaceId()
+			}
+		}
+
+		return bidirectionalEndpoint{
+			nodeID: nodeID,
+			txID:   txID,
+			rxID:   rxID,
+		}
+	}
+
+	func (e bidirectionalEndpoint) txInterface() string {
+		if e.txID != "" {
+			return e.txID
+		}
+		return e.rxID
+	}
+
+	func (e bidirectionalEndpoint) rxInterface() string {
+		if e.rxID != "" {
+			return e.rxID
+		}
+		return e.txID
+	}
+
+	func protoTimeToTime(dt *common.DateTime) time.Time {
+		if dt == nil {
+			return time.Time{}
+		}
+		return time.UnixMicro(dt.GetUnixTimeUsec())
+	}

--- a/internal/nbi/validation_test.go
+++ b/internal/nbi/validation_test.go
@@ -1,0 +1,312 @@
+package nbi
+
+import (
+	"testing"
+	"time"
+
+	common "aalyria.com/spacetime/api/common"
+	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestValidatePlatformProto(t *testing.T) {
+	name := "platform-valid"
+	typ := "SATELLITE"
+	motion := common.PlatformDefinition_SPACETRACK_ORG
+
+	valid := &common.PlatformDefinition{
+		Name:         &name,
+		Type:         &typ,
+		MotionSource: &motion,
+	}
+	if err := ValidatePlatformProto(valid); err != nil {
+		t.Fatalf("ValidatePlatformProto(valid) err = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name string
+		pd   *common.PlatformDefinition
+	}{
+		{name: "nil", pd: nil},
+		{name: "missing name", pd: &common.PlatformDefinition{Type: &typ}},
+		{name: "missing type", pd: &common.PlatformDefinition{Name: &name}},
+		{name: "satellite missing motion", pd: &common.PlatformDefinition{Name: &name, Type: &typ}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidatePlatformProto(tc.pd); err == nil {
+				t.Fatalf("ValidatePlatformProto(%s) = nil, want error", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateInterfaceProto(t *testing.T) {
+	if err := ValidateInterfaceProto(wiredInterfaceProto("eth0", "plat")); err != nil {
+		t.Fatalf("ValidateInterfaceProto(wired) err = %v, want nil", err)
+	}
+	if err := ValidateInterfaceProto(wirelessInterfaceProto("rf0", "trx", "plat")); err != nil {
+		t.Fatalf("ValidateInterfaceProto(wireless) err = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name  string
+		iface *resources.NetworkInterface
+	}{
+		{name: "nil", iface: nil},
+		{
+			name: "missing id",
+			iface: &resources.NetworkInterface{
+				InterfaceMedium: &resources.NetworkInterface_Wired{Wired: &resources.WiredDevice{}},
+			},
+		},
+		{
+			name:  "missing medium",
+			iface: &resources.NetworkInterface{InterfaceId: strPtr("if0")},
+		},
+		{
+			name:  "wireless missing transceiver",
+			iface: wirelessInterfaceProto("rf1", "", "plat"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateInterfaceProto(tc.iface); err == nil {
+				t.Fatalf("ValidateInterfaceProto(%s) = nil, want error", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateNodeProto(t *testing.T) {
+	valid := &resources.NetworkNode{
+		NodeId: strPtr("node-1"),
+		NodeInterface: []*resources.NetworkInterface{
+			wiredInterfaceProto("eth0", "plat"),
+			wirelessInterfaceProto("rf0", "trx", "plat"),
+		},
+	}
+	if err := ValidateNodeProto(valid); err != nil {
+		t.Fatalf("ValidateNodeProto(valid) err = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name string
+		node *resources.NetworkNode
+	}{
+		{name: "nil", node: nil},
+		{
+			name: "missing node id",
+			node: &resources.NetworkNode{
+				NodeInterface: []*resources.NetworkInterface{wiredInterfaceProto("eth0", "plat")},
+			},
+		},
+		{
+			name: "no interfaces",
+			node: &resources.NetworkNode{
+				NodeId: strPtr("node-no-iface"),
+			},
+		},
+		{
+			name: "duplicate interfaces",
+			node: &resources.NetworkNode{
+				NodeId: strPtr("node-dup"),
+				NodeInterface: []*resources.NetworkInterface{
+					wiredInterfaceProto("dup", "plat"),
+					wirelessInterfaceProto("dup", "trx", "plat"),
+				},
+			},
+		},
+		{
+			name: "wireless missing transceiver",
+			node: &resources.NetworkNode{
+				NodeId: strPtr("node-missing-trx"),
+				NodeInterface: []*resources.NetworkInterface{
+					wirelessInterfaceProto("rf0", "", "plat"),
+				},
+			},
+		},
+		{
+			name: "interface on different node",
+			node: &resources.NetworkNode{
+				NodeId: strPtr("node-wrong"),
+				NodeInterface: []*resources.NetworkInterface{
+					{
+						InterfaceId:     strPtr("other/eth0"),
+						InterfaceMedium: &resources.NetworkInterface_Wired{Wired: &resources.WiredDevice{}},
+					},
+				},
+			},
+		},
+		{
+			name: "conflicting platforms",
+			node: &resources.NetworkNode{
+				NodeId: strPtr("node-conflict"),
+				NodeInterface: []*resources.NetworkInterface{
+					wiredInterfaceProto("a", "plat-a"),
+					wiredInterfaceProto("b", "plat-b"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateNodeProto(tc.node); err == nil {
+				t.Fatalf("ValidateNodeProto(%s) = nil, want error", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateLinkProto(t *testing.T) {
+	nodeA := "node-a"
+	nodeB := "node-b"
+	ifaceA := "ifA"
+	ifaceB := "ifB"
+
+	valid := &resources.BidirectionalLink{
+		ANetworkNodeId: &nodeA,
+		ATxInterfaceId: &ifaceA,
+		ARxInterfaceId: &ifaceA,
+		BNetworkNodeId: &nodeB,
+		BTxInterfaceId: &ifaceB,
+		BRxInterfaceId: &ifaceB,
+	}
+	if err := ValidateLinkProto(valid); err != nil {
+		t.Fatalf("ValidateLinkProto(valid) err = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name string
+		link *resources.BidirectionalLink
+	}{
+		{name: "nil", link: nil},
+		{name: "missing endpoints", link: &resources.BidirectionalLink{}},
+		{
+			name: "self loop",
+			link: &resources.BidirectionalLink{
+				ANetworkNodeId: &nodeA,
+				ATxInterfaceId: &ifaceA,
+				ARxInterfaceId: &ifaceA,
+				BNetworkNodeId: &nodeA,
+				BTxInterfaceId: &ifaceA,
+				BRxInterfaceId: &ifaceA,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateLinkProto(tc.link); err == nil {
+				t.Fatalf("ValidateLinkProto(%s) = nil, want error", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateServiceRequestProto(t *testing.T) {
+	usecStart := time.Now().UnixMicro()
+	usecEnd := usecStart + int64(time.Minute/time.Microsecond)
+	bw := 1_000_000.0
+
+	valid := &resources.ServiceRequest{
+		Type:    strPtr("sr-valid"),
+		SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+		DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{
+				BandwidthBpsRequested: &bw,
+				LatencyMaximum:        durationpb.New(10 * time.Millisecond),
+				TimeInterval: &common.TimeInterval{
+					StartTime: &common.DateTime{UnixTimeUsec: &usecStart},
+					EndTime:   &common.DateTime{UnixTimeUsec: &usecEnd},
+				},
+			},
+		},
+	}
+	if err := ValidateServiceRequestProto(valid); err != nil {
+		t.Fatalf("ValidateServiceRequestProto(valid) err = %v, want nil", err)
+	}
+
+	negative := -1.0
+	earlyEnd := usecStart - int64(time.Minute/time.Microsecond)
+
+	tests := []struct {
+		name string
+		req  *resources.ServiceRequest
+	}{
+		{name: "nil", req: nil},
+		{
+			name: "missing src",
+			req: &resources.ServiceRequest{
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					{BandwidthBpsRequested: &bw},
+				},
+			},
+		},
+		{
+			name: "missing dst",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					{BandwidthBpsRequested: &bw},
+				},
+			},
+		},
+		{
+			name: "no requirements",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+			},
+		},
+		{
+			name: "negative bandwidth",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					{BandwidthBpsRequested: &negative},
+				},
+			},
+		},
+		{
+			name: "negative latency",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					{LatencyMaximum: durationpb.New(-1 * time.Second)},
+				},
+			},
+		},
+		{
+			name: "end before start",
+			req: &resources.ServiceRequest{
+				SrcType: &resources.ServiceRequest_SrcNodeId{SrcNodeId: "src"},
+				DstType: &resources.ServiceRequest_DstNodeId{DstNodeId: "dst"},
+				Requirements: []*resources.ServiceRequest_FlowRequirements{
+					{
+						BandwidthBpsRequested: &bw,
+						TimeInterval: &common.TimeInterval{
+							StartTime: &common.DateTime{UnixTimeUsec: &usecStart},
+							EndTime:   &common.DateTime{UnixTimeUsec: &earlyEnd},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateServiceRequestProto(tc.req); err == nil {
+				t.Fatalf("ValidateServiceRequestProto(%s) = nil, want error", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Introduce internal/nbi/validation.go with shared proto-level validators:
  - ValidatePlatformProto
  - ValidateNodeProto
  - ValidateInterfaceProto
  - ValidateLinkProto
  - ValidateServiceRequestProto
- Enforce common structural rules:
  - Platform: require name (used as ID) and type; SATELLITE platforms must specify a non-UNKNOWN motion source.
  - Node: require node_id and at least one interface; validate embedded interfaces and ensure interface IDs are unique per node and not bound to another node; enforce a single consistent platform_id across interfaces.
  - Interface: require interface_id and interface_medium; for wireless, require a transceiver_model_id.
  - Link: require both endpoints to specify node/interface IDs and disallow self-loop endpoints.
  - ServiceRequest: require src/dst node IDs, at least one flow requirement, non-negative bandwidth/latency, and valid time intervals (end >= start).
- Update Platform, Node, Link and ServiceRequest services to call the shared validation helpers instead of ad hoc per-service checks.
- Add validation_test.go with unit tests covering valid cases and key invalid configurations for each validator.