### PR TITLE
Add NBI perf benchmarks and baseline doc

### DIFF
--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -1,0 +1,35 @@
+# Performance baseline
+
+This document captures initial Scope-3 performance targets for the NBI bulk-create paths and records a baseline measurement gathered on a developer machine. These numbers are guidance targets, not guarantees.
+
+## Target scale
+- Platforms: 1,000
+- Network nodes: 1,000–3,000 (benchmarks cover 1,000 by default; 3,000 under `perf_large`)
+- Interfaces per node: 2 (wired, for consistency)
+- Links: 1,000 (default) / 3,000 (`perf_large`)
+- Service requests: 1,000 (default) / 3,000 (`perf_large`)
+
+## How to run
+- Default perf suite (not run in CI): `go test -run=^$ -bench=. -benchmem -tags=perf ./internal/nbi/perf`
+- Larger scale: `go test -run=^$ -bench=. -benchmem -tags=perf_large ./internal/nbi/perf`
+- Tests live in `internal/nbi/perf` and are guarded by build tags so `go test ./...` remains fast.
+
+## Baseline results
+- Environment: Windows dev machine, Go 1.24.10 (w/ default GC settings)
+- Hardware: (see below from `Get-CimInstance Win32_Processor` / `Win32_ComputerSystem`)
+- Command: `go test -run=^$ -bench=. -benchmem -tags=perf ./internal/nbi/perf`
+- Results (ops/sec approximate; lower is faster):
+  - `BenchmarkPlatformCreateSmall`: ~0.60 ms (≈1.7k ops/sec), 686 KB allocs, 15.8k allocs/op
+  - `BenchmarkNodeCreateSmall`: ~2.17 ms (≈460 ops/sec), 2.69 MB allocs, 54.8k allocs/op
+  - `BenchmarkLinkCreateSmall`: ~2.80 ms (≈360 ops/sec), 3.02 MB allocs, 60.1k allocs/op
+  - `BenchmarkServiceRequestCreateSmall`: ~0.60 ms (≈1.7k ops/sec), 1.04 MB allocs, 22.8k allocs/op
+  - Command used single-iteration timing (`-benchtime=1x`) to keep the run fast while capturing wall time and allocations.
+  - Hardware sample: 12th Gen Intel(R) Core(TM) i7-12700K (12 cores / 20 threads), ~128 GB RAM (137,167,814,656 bytes)
+
+## Notes and future work
+- Benchmarks use in-memory ScenarioState and NBI services to exercise the same validation and locking paths as gRPC handlers.
+- Interfaces are wired-only to keep setup light; wireless paths can be added once transceiver catalog seeding is cheap.
+- If contention shows up, likely areas to explore:
+  - Finer-grained read paths inside ScenarioState
+  - Pooling for frequently allocated protos / domain structs
+  - Batch APIs for bulk ingest

--- a/internal/nbi/perf/doc.go
+++ b/internal/nbi/perf/doc.go
@@ -1,0 +1,6 @@
+// Package perf hosts opt-in performance benchmarks for NBI bulk operations.
+//
+// The actual benchmarks are behind build tags (`perf`, `perf_large`) so they
+// stay out of default test runs, but having this file without tags keeps the
+// package discoverable by editors and `go list`.
+package perf

--- a/internal/nbi/perf/perf_large_test.go
+++ b/internal/nbi/perf/perf_large_test.go
@@ -1,0 +1,29 @@
+//go:build perf_large
+
+package perf
+
+import "testing"
+
+var largeConfig = perfConfig{
+	Platforms:         3000,
+	Nodes:             3000,
+	InterfacesPerNode: 2,
+	Links:             3000,
+	ServiceRequests:   3000,
+}
+
+func BenchmarkPlatformCreateLarge(b *testing.B) {
+	benchmarkPlatforms(b, largeConfig)
+}
+
+func BenchmarkNodeCreateLarge(b *testing.B) {
+	benchmarkNodes(b, largeConfig)
+}
+
+func BenchmarkLinkCreateLarge(b *testing.B) {
+	benchmarkLinks(b, largeConfig)
+}
+
+func BenchmarkServiceRequestCreateLarge(b *testing.B) {
+	benchmarkServiceRequests(b, largeConfig)
+}

--- a/internal/nbi/perf/perf_shared_test.go
+++ b/internal/nbi/perf/perf_shared_test.go
@@ -1,0 +1,209 @@
+//go:build perf || perf_large
+
+package perf
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	common "aalyria.com/spacetime/api/common"
+	resources "aalyria.com/spacetime/api/nbi/v1alpha/resources"
+	core "github.com/signalsfoundry/constellation-simulator/core"
+	"github.com/signalsfoundry/constellation-simulator/internal/nbi"
+	sim "github.com/signalsfoundry/constellation-simulator/internal/sim/state"
+	"github.com/signalsfoundry/constellation-simulator/kb"
+)
+
+type perfConfig struct {
+	Platforms         int
+	Nodes             int
+	InterfacesPerNode int
+	Links             int
+	ServiceRequests   int
+}
+
+func benchmarkPlatforms(b *testing.B, cfg perfConfig) {
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		state := newScenarioState()
+		svc := nbi.NewPlatformService(state, nil, nil)
+
+		b.ResetTimer()
+		for j := 0; j < cfg.Platforms; j++ {
+			id := fmt.Sprintf("platform-%d-%d", i, j)
+			typ := "GROUND_STATION"
+			if _, err := svc.CreatePlatform(ctx, &common.PlatformDefinition{
+				Name: &id,
+				Type: &typ,
+			}); err != nil {
+				b.Fatalf("CreatePlatform(%s): %v", id, err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchmarkNodes(b *testing.B, cfg perfConfig) {
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		state := newScenarioState()
+		svc := nbi.NewNetworkNodeService(state, nil)
+
+		b.ResetTimer()
+		for j := 0; j < cfg.Nodes; j++ {
+			nodeID := fmt.Sprintf("node-%d-%d", i, j)
+			if _, err := svc.CreateNode(ctx, nodeProto(nodeID, cfg.InterfacesPerNode)); err != nil {
+				b.Fatalf("CreateNode(%s): %v", nodeID, err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchmarkLinks(b *testing.B, cfg perfConfig) {
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		state := newScenarioState()
+		nodeSvc := nbi.NewNetworkNodeService(state, nil)
+		linkSvc := nbi.NewNetworkLinkService(state, nil)
+
+		nodeIDs := make([]string, 0, max(cfg.Nodes, cfg.Links+1))
+		for j := 0; j < cap(nodeIDs); j++ {
+			nodeID := fmt.Sprintf("link-node-%d-%d", i, j)
+			if _, err := nodeSvc.CreateNode(ctx, nodeProto(nodeID, 1)); err != nil {
+				b.Fatalf("seed CreateNode(%s): %v", nodeID, err)
+			}
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+
+		b.ResetTimer()
+		for j := 0; j < cfg.Links; j++ {
+			a := nodeIDs[j%len(nodeIDs)]
+			bID := nodeIDs[(j+1)%len(nodeIDs)]
+			if a == bID {
+				b.Fatalf("node ID reuse detected")
+			}
+			if _, err := linkSvc.CreateLink(ctx, linkProto(a, bID)); err != nil {
+				b.Fatalf("CreateLink(%s,%s): %v", a, bID, err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchmarkServiceRequests(b *testing.B, cfg perfConfig) {
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		state := newScenarioState()
+		nodeSvc := nbi.NewNetworkNodeService(state, nil)
+		srSvc := nbi.NewServiceRequestService(state, nil)
+
+		nodeIDs := make([]string, 0, max(cfg.Nodes, cfg.ServiceRequests+1))
+		for j := 0; j < cap(nodeIDs); j++ {
+			nodeID := fmt.Sprintf("sr-node-%d-%d", i, j)
+			if _, err := nodeSvc.CreateNode(ctx, nodeProto(nodeID, 1)); err != nil {
+				b.Fatalf("seed CreateNode(%s): %v", nodeID, err)
+			}
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+
+		b.ResetTimer()
+		for j := 0; j < cfg.ServiceRequests; j++ {
+			src := nodeIDs[j%len(nodeIDs)]
+			dst := nodeIDs[(j+1)%len(nodeIDs)]
+			if _, err := srSvc.CreateServiceRequest(ctx, serviceRequestProto(src, dst, j%5)); err != nil {
+				b.Fatalf("CreateServiceRequest(%s->%s): %v", src, dst, err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func newScenarioState() *sim.ScenarioState {
+	return sim.NewScenarioState(kb.NewKnowledgeBase(), core.NewKnowledgeBase())
+}
+
+func nodeProto(nodeID string, interfaces int) *resources.NetworkNode {
+	n := &resources.NetworkNode{
+		NodeId: stringPtr(nodeID),
+		Name:   stringPtr(nodeID),
+	}
+	for i := 0; i < interfaces; i++ {
+		ifaceID := fmt.Sprintf("if%d", i)
+		n.NodeInterface = append(n.NodeInterface, &resources.NetworkInterface{
+			InterfaceId: stringPtr(ifaceID),
+			InterfaceMedium: &resources.NetworkInterface_Wired{
+				Wired: &resources.WiredDevice{},
+			},
+		})
+	}
+	return n
+}
+
+func linkProto(aNode, bNode string) *resources.BidirectionalLink {
+	iface := "if0"
+	return &resources.BidirectionalLink{
+		ANetworkNodeId: stringPtr(aNode),
+		ATxInterfaceId: stringPtr(iface),
+		ARxInterfaceId: stringPtr(iface),
+		BNetworkNodeId: stringPtr(bNode),
+		BTxInterfaceId: stringPtr(iface),
+		BRxInterfaceId: stringPtr(iface),
+		// Populate deprecated fields to keep coverage of both formats.
+		A: &resources.LinkEnd{
+			Id: &common.NetworkInterfaceId{
+				NodeId:      stringPtr(aNode),
+				InterfaceId: stringPtr(iface),
+			},
+		},
+		B: &resources.LinkEnd{
+			Id: &common.NetworkInterfaceId{
+				NodeId:      stringPtr(bNode),
+				InterfaceId: stringPtr(iface),
+			},
+		},
+	}
+}
+
+func serviceRequestProto(src, dst string, priority int) *resources.ServiceRequest {
+	pr := float64(priority)
+	bw := float64(10_000_000)
+	minBw := float64(5_000_000)
+	id := fmt.Sprintf("sr-%s-%s-%d", src, dst, priority)
+
+	return &resources.ServiceRequest{
+		Type:     stringPtr(id),
+		SrcType:  &resources.ServiceRequest_SrcNodeId{SrcNodeId: src},
+		DstType:  &resources.ServiceRequest_DstNodeId{DstNodeId: dst},
+		Priority: &pr,
+		Requirements: []*resources.ServiceRequest_FlowRequirements{
+			{
+				BandwidthBpsRequested: &bw,
+				BandwidthBpsMinimum:   &minBw,
+			},
+		},
+	}
+}
+
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/nbi/perf/perf_small_test.go
+++ b/internal/nbi/perf/perf_small_test.go
@@ -1,0 +1,29 @@
+//go:build perf
+
+package perf
+
+import "testing"
+
+var smallConfig = perfConfig{
+	Platforms:         1000,
+	Nodes:             1000,
+	InterfacesPerNode: 2,
+	Links:             1000,
+	ServiceRequests:   1000,
+}
+
+func BenchmarkPlatformCreateSmall(b *testing.B) {
+	benchmarkPlatforms(b, smallConfig)
+}
+
+func BenchmarkNodeCreateSmall(b *testing.B) {
+	benchmarkNodes(b, smallConfig)
+}
+
+func BenchmarkLinkCreateSmall(b *testing.B) {
+	benchmarkLinks(b, smallConfig)
+}
+
+func BenchmarkServiceRequestCreateSmall(b *testing.B) {
+	benchmarkServiceRequests(b, smallConfig)
+}


### PR DESCRIPTION
- Add docs/architecture/performance.md with initial target scales for platforms, nodes, interfaces, links, and service requests plus example baseline results and commands for running the perf suite.
- Introduce internal/nbi/perf benchmarks guarded by perf/perf_large build tags so go test ./... remains fast by default.
- Implement BenchmarkPlatformCreate*, BenchmarkNodeCreate*, BenchmarkLinkCreate*, and BenchmarkServiceRequestCreate* using real NBI services and an in-memory ScenarioState to exercise bulk Create* paths end-to-end.
- Provide small (1k) and large (3k) configurations so we can quickly re-run perf baselines locally and watch for regressions over time.